### PR TITLE
Bump Python to 3.8

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,5 @@
 language: python
 python:
-  - "3.6"
+  - "3.8"
 script:
   - make test


### PR DESCRIPTION
This repo now uses a bunch of newer features:

- `typing.Protocol`
- the new “walrus operator”